### PR TITLE
Add basic project office with mock auth

### DIFF
--- a/frontend/components/CallToAction.tsx
+++ b/frontend/components/CallToAction.tsx
@@ -1,6 +1,14 @@
 import { motion } from "framer-motion";
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/router';
 
 export default function CallToAction() {
+  const { data: session } = useSession();
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push(session ? '/dashboard' : '/auth');
+  };
   return (
     <motion.section
       className="bg-gradient-to-r from-[#40E0D0] to-[#C084FC] text-white py-16 text-center"
@@ -12,12 +20,12 @@ export default function CallToAction() {
       <h2 className="text-3xl md:text-4xl font-semibold mb-6">
         Создай своё видео прямо сейчас
       </h2>
-      <a
-        href="/app"
+      <button
+        onClick={handleClick}
         className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-300 transition"
       >
-        Попробовать бесплатно
-      </a>
+        Создать видео
+      </button>
     </motion.section>
   );
 }

--- a/frontend/components/CompanyForm.tsx
+++ b/frontend/components/CompanyForm.tsx
@@ -1,0 +1,48 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Project } from '../lib/store';
+
+const schema = z.object({
+  companyName: z.string().min(1, 'Обязательное поле'),
+  sphere: z.string().optional(),
+  description: z.string().optional(),
+  niche: z.string().optional(),
+  mission: z.string().optional(),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function CompanyForm({ initial, onSave }: { initial?: Project; onSave: (data: FormData) => void }) {
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: initial ?? {}
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSave)} className="space-y-4">
+      <div>
+        <label className="block mb-1">Название компании</label>
+        <input className="w-full border rounded px-3 py-2" {...register('companyName')} />
+        {errors.companyName && <p className="text-red-500 text-sm">{errors.companyName.message}</p>}
+      </div>
+      <div>
+        <label className="block mb-1">Сфера деятельности</label>
+        <input className="w-full border rounded px-3 py-2" {...register('sphere')} />
+      </div>
+      <div>
+        <label className="block mb-1">Описание бизнеса</label>
+        <textarea className="w-full border rounded px-3 py-2" {...register('description')} />
+      </div>
+      <div>
+        <label className="block mb-1">Ниша</label>
+        <input className="w-full border rounded px-3 py-2" {...register('niche')} />
+      </div>
+      <div>
+        <label className="block mb-1">Миссия</label>
+        <textarea className="w-full border rounded px-3 py-2" {...register('mission')} />
+      </div>
+      <button type="submit" className="bg-brandTurquoise text-white px-4 py-2 rounded">Сохранить</button>
+    </form>
+  );
+}

--- a/frontend/components/Hero.tsx
+++ b/frontend/components/Hero.tsx
@@ -1,7 +1,14 @@
 import { motion } from "framer-motion";
 import BackgroundAnimation from "./BackgroundAnimation";
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/router';
 
 export default function Hero() {
+  const { data: session } = useSession();
+  const router = useRouter();
+  const handleClick = () => {
+    router.push(session ? '/dashboard' : '/auth');
+  };
   return (
     <section className="relative flex flex-col justify-center items-center h-screen text-center px-4 bg-gradient-to-br from-[#40E0D0] to-[#C084FC] text-white">
       <BackgroundAnimation />
@@ -21,15 +28,15 @@ export default function Hero() {
       >
         AI сам напишет сценарий, нарисует и озвучит
       </motion.p>
-      <motion.a
-        href="#scary-block"
+      <motion.button
+        onClick={handleClick}
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 0.4, duration: 0.8 }}
         className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-300 transition"
       >
-        Начать работу
-      </motion.a>
+        Создать видео
+      </motion.button>
     </section>
   );
 }

--- a/frontend/components/ProductCard.tsx
+++ b/frontend/components/ProductCard.tsx
@@ -1,0 +1,11 @@
+import Link from 'next/link';
+import { Product } from '../lib/store';
+
+export default function ProductCard({ product, projectId }: { product: Product; projectId: string }) {
+  return (
+    <Link href={`/project/${projectId}/product/${product.id}`} className="block bg-white rounded-xl shadow p-4 hover:shadow-lg transition">
+      <h4 className="font-medium mb-1">{product.name}</h4>
+      <p className="text-sm text-gray-500">Статус: {product.roadmap.find(r => r.id === '2')?.status === 'done' ? 'завершено' : 'в процессе'}</p>
+    </Link>
+  );
+}

--- a/frontend/components/ProductForm.tsx
+++ b/frontend/components/ProductForm.tsx
@@ -1,0 +1,65 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Product } from '../lib/store';
+
+const schema = z.object({
+  name: z.string().min(1, 'Обязательное поле'),
+  description: z.string().min(1),
+  targetAudience: z.string().min(1),
+  customerValues: z.string().min(1),
+  problem: z.string().min(1),
+  useCase: z.string().min(1),
+  funnelDescription: z.string().min(1),
+  productGoal: z.string().min(1)
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function ProductForm({ initial, onSave }: { initial?: Product; onSave: (values: FormData) => void }) {
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: initial
+      ? { ...initial, customerValues: initial.customerValues.join(', ') }
+      : {}
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSave)} className="space-y-4">
+      <div>
+        <label className="block mb-1">Название продукта</label>
+        <input className="w-full border rounded px-3 py-2" {...register('name')} />
+        {errors.name && <p className="text-red-500 text-sm">{errors.name.message}</p>}
+      </div>
+      <div>
+        <label className="block mb-1">Описание</label>
+        <textarea className="w-full border rounded px-3 py-2" {...register('description')} />
+      </div>
+      <div>
+        <label className="block mb-1">Целевая аудитория</label>
+        <textarea className="w-full border rounded px-3 py-2" {...register('targetAudience')} />
+      </div>
+      <div>
+        <label className="block mb-1">Ключевые клиентские ценности</label>
+        <textarea className="w-full border rounded px-3 py-2" {...register('customerValues')} />
+      </div>
+      <div>
+        <label className="block mb-1">Проблема</label>
+        <textarea className="w-full border rounded px-3 py-2" {...register('problem')} />
+      </div>
+      <div>
+        <label className="block mb-1">Сценарий использования</label>
+        <textarea className="w-full border rounded px-3 py-2" {...register('useCase')} />
+      </div>
+      <div>
+        <label className="block mb-1">Воронка продаж</label>
+        <textarea className="w-full border rounded px-3 py-2" {...register('funnelDescription')} />
+      </div>
+      <div>
+        <label className="block mb-1">Цель продукта</label>
+        <textarea className="w-full border rounded px-3 py-2" {...register('productGoal')} />
+      </div>
+      <button type="submit" className="bg-brandTurquoise text-white px-4 py-2 rounded">Сохранить</button>
+    </form>
+  );
+}

--- a/frontend/components/ProjectCard.tsx
+++ b/frontend/components/ProjectCard.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link';
+import { Project } from '../lib/store';
+
+export default function ProjectCard({ project }: { project: Project }) {
+  return (
+    <Link href={`/project/${project.id}`} className="block bg-white rounded-xl shadow p-4 hover:shadow-lg transition">
+      <h3 className="text-lg font-semibold mb-1">{project.companyName}</h3>
+      {project.sphere && <p className="text-sm text-gray-500 mb-1">{project.sphere}</p>}
+      <p className="text-xs text-gray-400">{new Date(project.createdAt).toLocaleDateString()}</p>
+    </Link>
+  );
+}

--- a/frontend/components/RoadmapStep.tsx
+++ b/frontend/components/RoadmapStep.tsx
@@ -1,0 +1,11 @@
+import { RoadmapStep } from '../lib/store';
+
+export default function RoadmapStepView({ step }: { step: RoadmapStep }) {
+  const statusColor = step.status === 'done' ? 'text-green-600' : step.status === 'in_progress' ? 'text-yellow-600' : 'text-gray-500';
+  return (
+    <div className="flex items-center space-x-2">
+      <span className={statusColor}>●</span>
+      <span>{step.title}</span>
+    </div>
+  );
+}

--- a/frontend/lib/store.ts
+++ b/frontend/lib/store.ts
@@ -1,0 +1,67 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface RoadmapStep {
+  id: string;
+  title: string;
+  status: 'not_started' | 'in_progress' | 'done';
+  data?: any;
+}
+
+export interface Product {
+  id: string;
+  name: string;
+  description: string;
+  targetAudience: string;
+  customerValues: string[];
+  problem: string;
+  useCase: string;
+  funnelDescription: string;
+  productGoal: string;
+  roadmap: RoadmapStep[];
+}
+
+export interface Project {
+  id: string;
+  companyName: string;
+  sphere?: string;
+  logo?: string;
+  description?: string;
+  niche?: string;
+  mission?: string;
+  createdAt: string;
+  products: Product[];
+}
+
+interface StoreState {
+  projects: Project[];
+  addProject: (project: Project) => void;
+  updateProject: (project: Project) => void;
+  addProduct: (projectId: string, product: Product) => void;
+  updateProduct: (projectId: string, product: Product) => void;
+}
+
+export const useStore = create<StoreState>()(
+  persist(
+    (set, get) => ({
+      projects: [],
+      addProject: (project) =>
+        set({ projects: [...get().projects, project] }),
+      updateProject: (project) =>
+        set({ projects: get().projects.map(p => p.id === project.id ? project : p) }),
+      addProduct: (projectId, product) =>
+        set({
+          projects: get().projects.map(p => p.id === projectId ? { ...p, products: [...p.products, product] } : p)
+        }),
+      updateProduct: (projectId, product) =>
+        set({
+          projects: get().projects.map(p =>
+            p.id === projectId
+              ? { ...p, products: p.products.map(pr => pr.id === product.id ? product : pr) }
+              : p
+          )
+        }),
+    }),
+    { name: 'ae-projects' }
+  )
+);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,15 +8,23 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@headlessui/react": "^2.2.6",
+        "@hookform/resolvers": "^5.2.0",
         "@tailwindcss/postcss": "^4.1.11",
         "autoprefixer": "^10.4.21",
         "framer-motion": "^12.23.9",
         "next": "13.4.12",
+        "next-auth": "^4.24.11",
         "postcss": "^8.5.6",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-hook-form": "^7.61.1",
+        "react-hot-toast": "^2.5.2",
         "tailwindcss": "^4.1.11",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "uuid": "^11.1.0",
+        "zod": "^4.0.10",
+        "zustand": "^5.0.6"
       },
       "devDependencies": {
         "@types/node": "^24.1.0",
@@ -47,6 +55,100 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.2.tgz",
+      "integrity": "sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.2.tgz",
+      "integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.2",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.4.tgz",
+      "integrity": "sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
+    "node_modules/@headlessui/react": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.6.tgz",
+      "integrity": "sha512-gN5CT8Kf4IWwL04GQOjZ/ZnHMFoeFHZmVSFoDKeTmbtmy9oFqQqJMthdBiO3Pl5LXk2w03fGFLpQV6EW84vjjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/interactions": "^3.25.0",
+        "@tanstack/react-virtual": "^3.13.9",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.0.tgz",
+      "integrity": "sha512-3YI+VqxJQH6ryRWG+j3k+M19Wf37LeSKJDg6Vdjq6makLOqZGYn77iTaYLMLpVi/uHc1N6OTCmcxJwhOQV979g==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -245,6 +347,118 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.0.tgz",
+      "integrity": "sha512-7NEGtTPsBy52EZ/ToVKCu0HSelE3kq9qeis+2eEq90XSuJOMaDHUQrA7RC2Y89tlEwQB31bud/kKRi9Qme1dkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/utils": "^3.30.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.25.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.4.tgz",
+      "integrity": "sha512-HBQMxgUPHrW8V63u9uGgBymkMfj6vdWbB0GgUJY49K9mBKMsypcHeWkWM6+bF7kxRO728/IK8bWDV6whDbqjHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/flags": "^3.1.2",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
+      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.30.0.tgz",
+      "integrity": "sha512-ydA6y5G1+gbem3Va2nczj/0G0W7/jUVo/cbN10WA5IizzWIwMP5qhFr7macgbKfHMkZ+YZC3oXnt2NNre5odKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
+      "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.10.8",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.8.tgz",
+      "integrity": "sha512-SN3/h7SzRsusVQjQ4v10LaVsDc81jyyR0DD5HnsQitm/I5WDpaSr2nRHtyloPFU48jlql1XX/S04T2DLQM7Y3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.31.0.tgz",
+      "integrity": "sha512-ua5U6V66gDcbLZe4P2QeyNgPp4YWD1ymGA6j3n+s8CGExtrCPe64v+g4mvpT8Bnb985R96e4zFT61+m0YCwqMg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.1",
@@ -516,6 +730,33 @@
         "tailwindcss": "4.1.11"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@types/node": {
       "version": "24.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
@@ -530,7 +771,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -651,11 +892,28 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -741,6 +999,15 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -754,6 +1021,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -1002,6 +1278,24 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-cache/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -1131,6 +1425,47 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "4.24.11",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
+      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
+      "license": "ISC",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@panva/hkdf": "^1.0.2",
+        "cookie": "^0.7.0",
+        "jose": "^4.15.5",
+        "oauth": "^0.9.15",
+        "openid-client": "^5.4.0",
+        "preact": "^10.6.3",
+        "preact-render-to-string": "^5.1.19",
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "@auth/core": "0.34.2",
+        "next": "^12.2.5 || ^13 || ^14 || ^15",
+        "nodemailer": "^6.6.5",
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@auth/core": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-auth/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
@@ -1155,6 +1490,15 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/next/node_modules/zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -1168,6 +1512,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "license": "MIT"
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/oidc-token-hash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.1.0.tgz",
+      "integrity": "sha512-y0W+X7Ppo7oZX6eovsRkuzcSM40Bicg2JEJkDJ4irIt1wsYAP5MLSNv+QAogO8xivMffw/9OvV3um1pxXgt1uA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.15.9",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/picocolors": {
@@ -1210,6 +1593,34 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/preact": {
+      "version": "10.26.9",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.9.tgz",
+      "integrity": "sha512-SSjF9vcnF27mJK1XyFMNJzFd5u3pQiATFqoaDy03XuN00u4ziveVVEGt5RKJrDR8MHE/wJo9Nnad56RLzS2RMA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
+      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "license": "MIT",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -1233,6 +1644,39 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.61.1.tgz",
+      "integrity": "sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/scheduler": {
@@ -1283,6 +1727,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.1.11",
@@ -1382,6 +1832,28 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -1405,12 +1877,41 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.10.tgz",
+      "integrity": "sha512-3vB+UU3/VmLL2lvwcY/4RV2i9z/YU0DTV/tDuYjrwmx5WeJ7hwy+rGEEx8glHp6Yxw7ibRbKSaIFBgReRPe5KA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.6.tgz",
+      "integrity": "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,15 +9,23 @@
     "export": "next export"
   },
   "dependencies": {
+    "@headlessui/react": "^2.2.6",
+    "@hookform/resolvers": "^5.2.0",
     "@tailwindcss/postcss": "^4.1.11",
     "autoprefixer": "^10.4.21",
     "framer-motion": "^12.23.9",
     "next": "13.4.12",
+    "next-auth": "^4.24.11",
     "postcss": "^8.5.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hook-form": "^7.61.1",
+    "react-hot-toast": "^2.5.2",
     "tailwindcss": "^4.1.11",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "uuid": "^11.1.0",
+    "zod": "^4.0.10",
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@types/node": "^24.1.0",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,7 +1,33 @@
-import type { AppProps } from 'next/app'
-import '../styles/globals.css'
-import '../styles/animations.css'
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+import '../styles/animations.css';
+import { SessionProvider } from 'next-auth/react';
+import { Toaster } from 'react-hot-toast';
+import { useRouter } from 'next/router';
+import { useState, useEffect } from 'react';
 
-export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+export default function App({ Component, pageProps: { session, ...pageProps } }: AppProps) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const handleStart = () => setLoading(true);
+    const handleStop = () => setLoading(false);
+    router.events.on('routeChangeStart', handleStart);
+    router.events.on('routeChangeComplete', handleStop);
+    router.events.on('routeChangeError', handleStop);
+    return () => {
+      router.events.off('routeChangeStart', handleStart);
+      router.events.off('routeChangeComplete', handleStop);
+      router.events.off('routeChangeError', handleStop);
+    };
+  }, [router]);
+
+  return (
+    <SessionProvider session={session}>
+      <Toaster position="top-right" />
+      {loading && <div className="fixed inset-0 bg-white bg-opacity-50 flex items-center justify-center">Загрузка...</div>}
+      <Component {...pageProps} />
+    </SessionProvider>
+  );
 }

--- a/frontend/pages/api/auth/[...nextauth].ts
+++ b/frontend/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,28 @@
+import NextAuth from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
+
+export default NextAuth({
+  providers: [
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' }
+      },
+      async authorize(credentials) {
+        const email = credentials?.email;
+        const password = credentials?.password;
+        if (email === 'demo@example.com' && password === 'demo') {
+          return { id: '1', name: 'Demo User', email };
+        }
+        return null;
+      }
+    })
+  ],
+  session: {
+    strategy: 'jwt'
+  },
+  pages: {
+    signIn: '/auth'
+  }
+});

--- a/frontend/pages/auth.tsx
+++ b/frontend/pages/auth.tsx
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { signIn, useSession } from 'next-auth/react';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1)
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function AuthPage() {
+  const { data: session } = useSession();
+  const router = useRouter();
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({
+    resolver: zodResolver(schema)
+  });
+
+  useEffect(() => {
+    if (session) router.replace('/dashboard');
+  }, [session, router]);
+
+  const onSubmit = async (data: FormData) => {
+    const res = await signIn('credentials', {
+      redirect: false,
+      email: data.email,
+      password: data.password
+    });
+    if (res?.ok) router.push('/dashboard');
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
+      <form onSubmit={handleSubmit(onSubmit)} className="bg-white p-6 rounded-xl shadow-md w-full max-w-sm space-y-4">
+        <h1 className="text-xl font-semibold text-center">Вход</h1>
+        <div>
+          <label className="block mb-1">Email</label>
+          <input type="email" {...register('email')} className="w-full border rounded px-3 py-2" />
+          {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
+        </div>
+        <div>
+          <label className="block mb-1">Пароль</label>
+          <input type="password" {...register('password')} className="w-full border rounded px-3 py-2" />
+          {errors.password && <p className="text-red-500 text-sm">{errors.password.message}</p>}
+        </div>
+        <button type="submit" className="w-full bg-brandTurquoise text-white py-2 rounded-md hover:bg-brandViolet transition">Войти</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -1,0 +1,62 @@
+import { useSession, getSession } from 'next-auth/react';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import ProjectCard from '../components/ProjectCard';
+import CompanyForm from '../components/CompanyForm';
+import { Dialog } from '@headlessui/react';
+import { useStore, Project } from '../lib/store';
+import { v4 as uuid } from 'uuid';
+import toast from 'react-hot-toast';
+
+export default function Dashboard() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const projects = useStore(s => s.projects);
+  const addProject = useStore(s => s.addProject);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (status === 'unauthenticated') router.replace('/auth');
+  }, [status, router]);
+
+  if (!session) return null;
+
+  const handleCreate = (data: any) => {
+    const project: Project = {
+      id: uuid(),
+      companyName: data.companyName,
+      sphere: data.sphere,
+      description: data.description,
+      niche: data.niche,
+      mission: data.mission,
+      createdAt: new Date().toISOString(),
+      products: [],
+    };
+    addProject(project);
+    setOpen(false);
+    toast.success('Проект создан');
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold mb-4">Мои проекты</h1>
+      <button onClick={() => setOpen(true)} className="bg-brandTurquoise text-white px-4 py-2 rounded">
+        Создать новый проект
+      </button>
+      <div className="grid md:grid-cols-3 gap-4 mt-4">
+        {projects.map(p => (
+          <ProjectCard key={p.id} project={p} />
+        ))}
+      </div>
+
+      <Dialog open={open} onClose={() => setOpen(false)} className="fixed z-10 inset-0 overflow-y-auto">
+        <div className="flex items-center justify-center min-h-screen p-4">
+          <Dialog.Panel className="bg-white p-6 rounded-xl shadow-xl w-full max-w-md">
+            <Dialog.Title className="text-lg font-semibold mb-4">Новый проект</Dialog.Title>
+            <CompanyForm onSave={handleCreate} />
+          </Dialog.Panel>
+        </div>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/pages/project/[projectId].tsx
+++ b/frontend/pages/project/[projectId].tsx
@@ -1,0 +1,78 @@
+import { useRouter } from 'next/router';
+import { useStore, Project } from '../../lib/store';
+import CompanyForm from '../../components/CompanyForm';
+import ProductCard from '../../components/ProductCard';
+import ProductForm from '../../components/ProductForm';
+import { Dialog } from '@headlessui/react';
+import { useState } from 'react';
+import { v4 as uuid } from 'uuid';
+import toast from 'react-hot-toast';
+
+export default function ProjectPage() {
+  const router = useRouter();
+  const { id } = router.query as { id: string };
+  const project = useStore(s => s.projects.find(p => p.id === id));
+  const updateProject = useStore(s => s.updateProject);
+  const addProduct = useStore(s => s.addProduct);
+  const [open, setOpen] = useState(false);
+
+  if (!project) return <p className="p-6">Проект не найден</p>;
+
+  const handleSaveCompany = (data: any) => {
+    updateProject({ ...project, ...data });
+    toast.success('Сохранено');
+  };
+
+  const handleCreateProduct = (data: any) => {
+    addProduct(project.id, {
+      id: uuid(),
+      name: data.name,
+      description: data.description,
+      targetAudience: data.targetAudience,
+      customerValues: data.customerValues.split(',').map((s: string) => s.trim()),
+      problem: data.problem,
+      useCase: data.useCase,
+      funnelDescription: data.funnelDescription,
+      productGoal: data.productGoal,
+      roadmap: [
+        { id: '1', title: 'Бизнес-анализ', status: 'done' },
+        { id: '2', title: 'Написание сценария', status: 'not_started' },
+        { id: '3', title: 'Выбор визуального стиля', status: 'not_started' },
+        { id: '4', title: 'Генерация ключевых кадров', status: 'not_started' },
+        { id: '5', title: 'Анимация', status: 'not_started' },
+        { id: '6', title: 'Монтаж и озвучка', status: 'not_started' },
+        { id: '7', title: 'Экспорт финального видео', status: 'not_started' },
+      ]
+    });
+    setOpen(false);
+    toast.success('Продукт добавлен');
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold mb-4">{project.companyName}</h1>
+      <CompanyForm initial={project} onSave={handleSaveCompany} />
+
+      <div className="flex items-center justify-between mt-8">
+        <h2 className="text-xl font-semibold">Продукты</h2>
+        <button onClick={() => setOpen(true)} className="bg-brandTurquoise text-white px-4 py-2 rounded">
+          Добавить продукт
+        </button>
+      </div>
+      <div className="grid md:grid-cols-2 gap-4">
+        {project.products.map(pr => (
+          <ProductCard key={pr.id} projectId={project.id} product={pr} />
+        ))}
+      </div>
+
+      <Dialog open={open} onClose={() => setOpen(false)} className="fixed z-10 inset-0 overflow-y-auto">
+        <div className="flex items-center justify-center min-h-screen p-4">
+          <Dialog.Panel className="bg-white p-6 rounded-xl shadow-xl w-full max-w-md">
+            <Dialog.Title className="text-lg font-semibold mb-4">Новый продукт</Dialog.Title>
+            <ProductForm onSave={handleCreateProduct} />
+          </Dialog.Panel>
+        </div>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/pages/project/[projectId]/product/[productId].tsx
+++ b/frontend/pages/project/[projectId]/product/[productId].tsx
@@ -1,0 +1,35 @@
+import { useRouter } from 'next/router';
+import { useStore } from '../../../../lib/store';
+import ProductForm from '../../../../components/ProductForm';
+import RoadmapStepView from '../../../../components/RoadmapStep';
+import toast from 'react-hot-toast';
+
+export default function ProductPage() {
+  const router = useRouter();
+  const { projectId, productId } = router.query as { projectId: string; productId: string };
+  const project = useStore(s => s.projects.find(p => p.id === projectId));
+  const updateProduct = useStore(s => s.updateProduct);
+
+  if (!project) return <p className="p-6">Проект не найден</p>;
+  const product = project.products.find(p => p.id === productId);
+  if (!product) return <p className="p-6">Продукт не найден</p>;
+
+  const handleSave = (data: any) => {
+    updateProduct(project.id, { ...product, ...data });
+    toast.success('Сохранено');
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">{product.name}</h1>
+      <ProductForm initial={product} onSave={handleSave} />
+
+      <h2 className="text-xl font-semibold mt-6">Дорожная карта</h2>
+      <div className="space-y-2">
+        {product.roadmap.map(step => (
+          <RoadmapStepView key={step.id} step={step} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -3,7 +3,8 @@
 @tailwind utilities;
 
 body {
-  @apply bg-gradient-to-br from-[#40E0D0] to-[#C084FC] text-white font-sans;
+  @apply bg-gradient-to-br from-[#40E0D0] to-[#C084FC] font-sans;
+  color: white;
 }
 
 h1, h2 {


### PR DESCRIPTION
## Summary
- add next-auth credentials provider
- implement Zustand store for projects/products
- create forms and cards for projects and products
- build dashboard and project/product pages
- add toast messages and simple route loader
- add CTA and hero logic for auth redirect

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688382254f0c832086ad909d4478ad25