### PR TITLE
Add script generation page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 OPENAI_KEY=fake-openai-key
 ELEVENLABS_KEY=fake-elevenlabs-key
 ANIX_API_KEY=fake-anix-key
+SCRIPT_SYSTEM_PROMPT=placeholder-script-prompt

--- a/frontend/components/ProgressBar.tsx
+++ b/frontend/components/ProgressBar.tsx
@@ -1,0 +1,14 @@
+export const steps = ['Бизнес-анализ', 'Сценарий', 'Визуальный стиль', 'Кадры', 'Анимация', 'Озвучка', 'Финал']
+
+export default function ProgressBar({ current }: { current: number }) {
+  return (
+    <div className="flex space-x-2 text-sm mb-4">
+      {steps.map((step, idx) => (
+        <div key={step} className="flex items-center">
+          <span className={idx === current ? 'font-semibold text-brandViolet' : ''}>{step}</span>
+          {idx < steps.length - 1 && <span className="mx-2 text-gray-400">&rarr;</span>}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/components/RationaleBox.tsx
+++ b/frontend/components/RationaleBox.tsx
@@ -1,0 +1,17 @@
+interface Props {
+  text: string
+  onChange: (t: string) => void
+}
+
+export default function RationaleBox({ text, onChange }: Props) {
+  return (
+    <div>
+      <label className="block mb-1">Обоснование сценария</label>
+      <textarea
+        className="w-full border rounded px-2 py-1"
+        value={text}
+        onChange={e => onChange(e.target.value)}
+      />
+    </div>
+  )
+}

--- a/frontend/components/SceneCard.tsx
+++ b/frontend/components/SceneCard.tsx
@@ -1,0 +1,39 @@
+import { Scene } from '../lib/store'
+
+interface Props {
+  scene: Scene
+  onChange: (scene: Scene) => void
+}
+
+export default function SceneCard({ scene, onChange }: Props) {
+  return (
+    <div className="border rounded p-3 space-y-2">
+      <input
+        className="w-full border rounded px-2 py-1"
+        value={scene.title}
+        onChange={e => onChange({ ...scene, title: e.target.value })}
+      />
+      <textarea
+        className="w-full border rounded px-2 py-1"
+        value={scene.description}
+        onChange={e => onChange({ ...scene, description: e.target.value })}
+      />
+      <label className="flex items-center space-x-2 text-sm">
+        <input
+          type="checkbox"
+          checked={scene.lipsync}
+          onChange={e => onChange({ ...scene, lipsync: e.target.checked })}
+        />
+        <span>Нужен липсинг?</span>
+      </label>
+      {scene.lipsync && (
+        <input
+          className="w-full border rounded px-2 py-1"
+          placeholder="Текст для губ"
+          value={scene.lipsyncText || ''}
+          onChange={e => onChange({ ...scene, lipsyncText: e.target.value })}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/components/ScriptEditor.tsx
+++ b/frontend/components/ScriptEditor.tsx
@@ -1,0 +1,43 @@
+import { ScriptOutput, Scene } from '../lib/store'
+import SceneCard from './SceneCard'
+import VoiceoverEditor from './VoiceoverEditor'
+import RationaleBox from './RationaleBox'
+import { useState } from 'react'
+
+export default function ScriptEditor({ initial, onChange }: { initial?: ScriptOutput; onChange: (s: ScriptOutput) => void }) {
+  const [data, setData] = useState<ScriptOutput>(
+    initial || { storyboard: [], voiceoverText: '', rationale: '' }
+  )
+
+  const updateScene = (idx: number, scene: Scene) => {
+    const storyboard = [...data.storyboard]
+    storyboard[idx] = scene
+    const newData = { ...data, storyboard }
+    setData(newData)
+    onChange(newData)
+  }
+
+  return (
+    <div className="space-y-4">
+      {data.storyboard.map((scene, idx) => (
+        <SceneCard key={scene.id} scene={scene} onChange={sc => updateScene(idx, sc)} />
+      ))}
+      <VoiceoverEditor
+        text={data.voiceoverText}
+        onChange={val => {
+          const newData = { ...data, voiceoverText: val }
+          setData(newData)
+          onChange(newData)
+        }}
+      />
+      <RationaleBox
+        text={data.rationale}
+        onChange={val => {
+          const newData = { ...data, rationale: val }
+          setData(newData)
+          onChange(newData)
+        }}
+      />
+    </div>
+  )
+}

--- a/frontend/components/VoiceoverEditor.tsx
+++ b/frontend/components/VoiceoverEditor.tsx
@@ -1,0 +1,17 @@
+interface Props {
+  text: string
+  onChange: (t: string) => void
+}
+
+export default function VoiceoverEditor({ text, onChange }: Props) {
+  return (
+    <div>
+      <label className="block mb-1">Текст закадрового голоса</label>
+      <textarea
+        className="w-full border rounded px-2 py-1"
+        value={text}
+        onChange={e => onChange(e.target.value)}
+      />
+    </div>
+  )
+}

--- a/frontend/lib/store.ts
+++ b/frontend/lib/store.ts
@@ -8,6 +8,20 @@ export interface RoadmapStep {
   data?: any;
 }
 
+export interface Scene {
+  id: string;
+  title: string;
+  description: string;
+  lipsync: boolean;
+  lipsyncText?: string;
+}
+
+export interface ScriptOutput {
+  storyboard: Scene[];
+  voiceoverText: string;
+  rationale: string;
+}
+
 export interface Product {
   id: string;
   name: string;
@@ -18,6 +32,7 @@ export interface Product {
   useCase: string;
   funnelDescription: string;
   productGoal: string;
+  script?: ScriptOutput;
   roadmap: RoadmapStep[];
 }
 

--- a/frontend/pages/api/generate-script.ts
+++ b/frontend/pages/api/generate-script.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { ScriptOutput } from '../../lib/store'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse<ScriptOutput>) {
+  if (req.method !== 'POST') {
+    res.status(405).end()
+    return
+  }
+
+  const systemPrompt = process.env.SCRIPT_SYSTEM_PROMPT || ''
+  const { business } = req.body
+
+  // In real app combine systemPrompt with business and call LLM
+  const mock: ScriptOutput = {
+    storyboard: [
+      { id: 'scene-1', title: 'Проблема клиента', description: 'Клиент в панике: не может понять, зачем ему продукт.', lipsync: false },
+      { id: 'scene-2', title: 'Появляется объяснение', description: 'На экране — простая графика, рассказывающая суть.', lipsync: true, lipsyncText: 'Наш продукт помогает вам решить проблему — быстро и понятно.' }
+    ],
+    voiceoverText: 'Наш продукт помогает вам решить проблему быстро и понятно.',
+    rationale: 'Сценарий отражает заявленные ценности и проблемы клиента.'
+  }
+
+  res.status(200).json(mock)
+}

--- a/frontend/pages/project/[projectId]/product/[productId]/frames.tsx
+++ b/frontend/pages/project/[projectId]/product/[productId]/frames.tsx
@@ -1,0 +1,19 @@
+import { useRouter } from 'next/router'
+import { useStore } from '../../../../../lib/store'
+import ProgressBar from '../../../../../components/ProgressBar'
+
+export default function FramesPage() {
+  const router = useRouter()
+  const { projectId, productId } = router.query as { projectId: string; productId: string }
+  const project = useStore(s => s.projects.find(p => p.id === projectId))
+  if (!project) return <p className="p-6">Проект не найден</p>
+  const product = project.products.find(p => p.id === productId)
+  if (!product) return <p className="p-6">Продукт не найден</p>
+  return (
+    <div className="p-6 space-y-4">
+      <ProgressBar current={3} />
+      <h1 className="text-2xl font-bold mb-4">Ключевые кадры для {product.name}</h1>
+      <p>Здесь будет генерация ключевых кадров.</p>
+    </div>
+  )
+}

--- a/frontend/pages/project/[projectId]/product/[productId]/index.tsx
+++ b/frontend/pages/project/[projectId]/product/[productId]/index.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
-import { useStore } from '../../../../lib/store';
-import ProductForm from '../../../../components/ProductForm';
-import RoadmapStepView from '../../../../components/RoadmapStep';
+import { useStore } from '../../../../../lib/store';
+import ProductForm from '../../../../../components/ProductForm';
+import RoadmapStepView from '../../../../../components/RoadmapStep';
 import toast from 'react-hot-toast';
 
 export default function ProductPage() {

--- a/frontend/pages/project/[projectId]/product/[productId]/script.tsx
+++ b/frontend/pages/project/[projectId]/product/[productId]/script.tsx
@@ -1,0 +1,61 @@
+import { useRouter } from 'next/router'
+import { useStore, ScriptOutput } from '../../../../../lib/store'
+import { useState } from 'react'
+import ScriptEditor from '../../../../../components/ScriptEditor'
+import ProgressBar from '../../../../../components/ProgressBar'
+import toast from 'react-hot-toast'
+
+export default function ScriptPage() {
+  const router = useRouter()
+  const { projectId, productId } = router.query as { projectId: string; productId: string }
+  const project = useStore(s => s.projects.find(p => p.id === projectId))
+  const updateProduct = useStore(s => s.updateProduct)
+
+  if (!project) return <p className="p-6">Проект не найден</p>
+  const product = project.products.find(p => p.id === productId)
+  if (!product) return <p className="p-6">Продукт не найден</p>
+
+  const [loading, setLoading] = useState(false)
+
+  const handleGenerate = async () => {
+    setLoading(true)
+    const res = await fetch('/api/generate-script', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ business: product })
+    })
+    const data: ScriptOutput = await res.json()
+    updateProduct(project.id, { ...product, script: data })
+    toast.success('Сценарий сгенерирован')
+    setLoading(false)
+  }
+
+  const handleSave = (script: ScriptOutput) => {
+    updateProduct(project.id, { ...product, script })
+  }
+
+  return (
+    <div className="p-6 space-y-4">
+      <ProgressBar current={1} />
+      <h1 className="text-2xl font-bold mb-4">Сценарий для {product.name}</h1>
+      {!product.script && (
+        <button onClick={handleGenerate} disabled={loading} className="bg-brandTurquoise text-white px-4 py-2 rounded">
+          {loading ? 'Генерация...' : 'Сгенерировать сценарий'}
+        </button>
+      )}
+      {product.script && (
+        <div className="space-y-4">
+          <ScriptEditor initial={product.script} onChange={handleSave} />
+          <div className="flex space-x-2">
+            <button onClick={handleGenerate} className="bg-brandPink text-white px-4 py-2 rounded">
+              Перегенерировать
+            </button>
+            <button onClick={() => router.push(`/project/${project.id}/product/${product.id}/frames`)} className="bg-brandTurquoise text-white px-4 py-2 rounded">
+              Перейти к ключевым кадрам
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add script and scene types to store
- create API endpoint `/api/generate-script`
- add components for editing scripts
- move product page to subfolder and add script/frames pages
- include progress bar component and env variable

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883873840e08320b62a324169ff7b8d