### PR TITLE
Implement key frame generation page

### DIFF
--- a/frontend/components/FooterProgress.tsx
+++ b/frontend/components/FooterProgress.tsx
@@ -1,0 +1,24 @@
+interface Props {
+  selected: number
+  total: number
+  disabled?: boolean
+  onNext: () => void
+}
+
+export default function FooterProgress({ selected, total, disabled, onNext }: Props) {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-white shadow-inner p-4 flex justify-between items-center">
+      <span>
+        Выбрано {selected} из {total} ключевых кадров
+      </span>
+      <button
+        onClick={onNext}
+        disabled={disabled}
+        className="bg-brandTurquoise text-white px-4 py-2 rounded disabled:opacity-50"
+      >
+        Перейти к этапу анимации
+      </button>
+    </div>
+  )
+}
+

--- a/frontend/components/FrameGenerationPanel.tsx
+++ b/frontend/components/FrameGenerationPanel.tsx
@@ -1,0 +1,98 @@
+import { useState, useEffect } from 'react'
+import { Scene, GeneratedImage } from '../lib/store'
+import SceneFrameCard from './SceneFrameCard'
+import FooterProgress from './FooterProgress'
+import { useRouter } from 'next/router'
+
+interface Style { id: string; url: string }
+
+interface Props {
+  projectId: string
+  productId: string
+  scenes: Scene[]
+  initialFrames?: Record<string, GeneratedImage>
+  onSave: (frames: Record<string, GeneratedImage>) => void
+}
+
+export default function FrameGenerationPanel({ projectId, productId, scenes, initialFrames, onSave }: Props) {
+  const router = useRouter()
+  const [prompts, setPrompts] = useState<Record<string, string>>(() => {
+    const obj: Record<string, string> = {}
+    scenes.forEach(sc => {
+      obj[sc.id] = sc.description
+    })
+    return obj
+  })
+  const [formats, setFormats] = useState<Record<string, '16:9' | '9:16'>>(() => {
+    const obj: Record<string, '16:9' | '9:16'> = {}
+    scenes.forEach(sc => {
+      obj[sc.id] = '16:9'
+    })
+    return obj
+  })
+  const [images, setImages] = useState<Record<string, GeneratedImage[]>>({})
+  const [selected, setSelected] = useState<Record<string, GeneratedImage>>(initialFrames || {})
+  const [loading, setLoading] = useState<Record<string, boolean>>({})
+  const [styles, setStyles] = useState<Style[]>([])
+  const [styleId, setStyleId] = useState<string>()
+
+  useEffect(() => {
+    fetch('/api/styles')
+      .then(res => res.json())
+      .then(setStyles)
+  }, [])
+
+  const generate = async (sceneId: string) => {
+    setLoading(l => ({ ...l, [sceneId]: true }))
+    const res = await fetch('/api/generate-frame', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sceneId,
+        prompt: prompts[sceneId],
+        format: formats[sceneId],
+        styleId
+      })
+    })
+    const data: GeneratedImage[] = await res.json()
+    setImages(i => ({ ...i, [sceneId]: data }))
+    setLoading(l => ({ ...l, [sceneId]: false }))
+  }
+
+  const select = (sceneId: string, img: GeneratedImage) => {
+    const next = { ...selected, [sceneId]: img }
+    setSelected(next)
+    onSave(next)
+  }
+
+  const allSelected = scenes.every(sc => selected[sc.id])
+
+  const goNext = () => {
+    router.push(`/project/${projectId}/product/${productId}/animation`)
+  }
+
+  return (
+    <div className="space-y-6 pb-24">
+      {scenes.map(sc => (
+        <SceneFrameCard
+          key={sc.id}
+          scene={sc}
+          prompt={prompts[sc.id]}
+          format={formats[sc.id]}
+          styles={styles}
+          selectedStyle={styleId}
+          images={images[sc.id]}
+          generating={loading[sc.id]}
+          selectedImage={selected[sc.id]}
+          onPromptChange={val => setPrompts(p => ({ ...p, [sc.id]: val }))}
+          onFormatChange={val => setFormats(f => ({ ...f, [sc.id]: val }))}
+          onStyleSelect={setStyleId}
+          onGenerate={() => generate(sc.id)}
+          onSelectImage={img => select(sc.id, img)}
+        />
+      ))}
+      <FooterProgress selected={Object.keys(selected).length} total={scenes.length} disabled={!allSelected} onNext={goNext} />
+    </div>
+  )
+}
+

--- a/frontend/components/ImageVariants.tsx
+++ b/frontend/components/ImageVariants.tsx
@@ -1,0 +1,27 @@
+import { GeneratedImage } from '../lib/store'
+
+interface Props {
+  images: GeneratedImage[]
+  selected?: GeneratedImage
+  onSelect: (img: GeneratedImage) => void
+}
+
+export default function ImageVariants({ images, selected, onSelect }: Props) {
+  if (!images || images.length === 0) return null
+  return (
+    <div className="grid grid-cols-4 gap-2 mt-2">
+      {images.map(img => (
+        <button
+          type="button"
+          key={img.id}
+          onClick={() => onSelect(img)}
+          className={`rounded overflow-hidden border ${selected?.id === img.id ? 'border-brandViolet' : 'border-transparent'}`}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={img.url} alt="variant" className="w-full h-24 object-cover" />
+        </button>
+      ))}
+    </div>
+  )
+}
+

--- a/frontend/components/SceneFrameCard.tsx
+++ b/frontend/components/SceneFrameCard.tsx
@@ -1,0 +1,69 @@
+import { Scene, GeneratedImage } from '../lib/store'
+import StyleGallery from './StyleGallery'
+import ImageVariants from './ImageVariants'
+
+interface Props {
+  scene: Scene
+  prompt: string
+  format: '16:9' | '9:16'
+  styles: { id: string; url: string }[]
+  selectedStyle?: string
+  images?: GeneratedImage[]
+  generating?: boolean
+  selectedImage?: GeneratedImage
+  onPromptChange: (val: string) => void
+  onFormatChange: (val: '16:9' | '9:16') => void
+  onStyleSelect: (id: string) => void
+  onGenerate: () => void
+  onSelectImage: (img: GeneratedImage) => void
+}
+
+export default function SceneFrameCard({
+  scene,
+  prompt,
+  format,
+  styles,
+  selectedStyle,
+  images,
+  generating,
+  selectedImage,
+  onPromptChange,
+  onFormatChange,
+  onStyleSelect,
+  onGenerate,
+  onSelectImage
+}: Props) {
+  return (
+    <div className="bg-white rounded-xl shadow-lg p-4 space-y-2">
+      <h3 className="font-semibold">{scene.title}</h3>
+      <p className="text-sm text-gray-500">{scene.description}</p>
+      <textarea
+        className="w-full border rounded px-2 py-1"
+        value={prompt}
+        onChange={e => onPromptChange(e.target.value)}
+      />
+      <select
+        className="border rounded px-2 py-1"
+        value={format}
+        onChange={e => onFormatChange(e.target.value as '16:9' | '9:16')}
+      >
+        <option value="16:9">16:9</option>
+        <option value="9:16">9:16</option>
+      </select>
+      <StyleGallery styles={styles} selected={selectedStyle} onSelect={onStyleSelect} />
+      {images ? (
+        <>
+          <ImageVariants images={images} selected={selectedImage} onSelect={onSelectImage} />
+          <button onClick={onGenerate} className="bg-brandPink text-white px-2 py-1 rounded">
+            Сгенерировать заново
+          </button>
+        </>
+      ) : (
+        <button onClick={onGenerate} disabled={generating} className="bg-brandTurquoise text-white px-4 py-2 rounded">
+          {generating ? 'Генерация...' : 'Сгенерировать изображение'}
+        </button>
+      )}
+    </div>
+  )
+}
+

--- a/frontend/components/StyleGallery.tsx
+++ b/frontend/components/StyleGallery.tsx
@@ -1,0 +1,29 @@
+interface Style {
+  id: string
+  url: string
+}
+
+interface Props {
+  styles: Style[]
+  selected?: string
+  onSelect: (id: string) => void
+}
+
+export default function StyleGallery({ styles, selected, onSelect }: Props) {
+  return (
+    <div className="grid grid-cols-4 gap-2">
+      {styles.map(style => (
+        <button
+          type="button"
+          key={style.id}
+          onClick={() => onSelect(style.id)}
+          className={`rounded overflow-hidden border ${selected === style.id ? 'border-brandViolet' : 'border-transparent'}`}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={style.url} alt="style" className="w-full h-20 object-cover" />
+        </button>
+      ))}
+    </div>
+  )
+}
+

--- a/frontend/lib/store.ts
+++ b/frontend/lib/store.ts
@@ -22,6 +22,13 @@ export interface ScriptOutput {
   rationale: string;
 }
 
+export interface GeneratedImage {
+  id: string;
+  url: string;
+  sceneId: string;
+  promptUsed: string;
+}
+
 export interface Product {
   id: string;
   name: string;
@@ -33,6 +40,11 @@ export interface Product {
   funnelDescription: string;
   productGoal: string;
   script?: ScriptOutput;
+  /**
+   * Selected keyframes for scenes of this product.
+   * Map of sceneId to chosen image.
+   */
+  frames?: Record<string, GeneratedImage>;
   roadmap: RoadmapStep[];
 }
 

--- a/frontend/pages/api/generate-frame.ts
+++ b/frontend/pages/api/generate-frame.ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { v4 as uuid } from 'uuid'
+import { GeneratedImage } from '../../lib/store'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse<GeneratedImage[]>) {
+  if (req.method !== 'POST') {
+    res.status(405).end()
+    return
+  }
+
+  const { sceneId, prompt, format, styleId } = req.body
+  const base = format === '16:9' ? 'https://via.placeholder.com/640x360' : 'https://via.placeholder.com/360x640'
+  const images: GeneratedImage[] = Array.from({ length: 4 }).map((_, i) => ({
+    id: uuid(),
+    url: `${base}?text=${styleId || 'style'}+${i + 1}`,
+    sceneId,
+    promptUsed: prompt
+  }))
+  res.status(200).json(images)
+}
+

--- a/frontend/pages/api/select-frame.ts
+++ b/frontend/pages/api/select-frame.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).end()
+    return
+  }
+
+  // In a real app selected frame would be persisted
+  res.status(200).json({ ok: true })
+}
+

--- a/frontend/pages/api/styles.ts
+++ b/frontend/pages/api/styles.ts
@@ -1,0 +1,14 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+interface Style { id: string; url: string }
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse<Style[]>) {
+  const styles: Style[] = [
+    { id: 'style-1', url: 'https://via.placeholder.com/150?text=Style+1' },
+    { id: 'style-2', url: 'https://via.placeholder.com/150?text=Style+2' },
+    { id: 'style-3', url: 'https://via.placeholder.com/150?text=Style+3' },
+    { id: 'style-4', url: 'https://via.placeholder.com/150?text=Style+4' }
+  ]
+  res.status(200).json(styles)
+}
+

--- a/frontend/pages/project/[projectId]/product/[productId]/frames.tsx
+++ b/frontend/pages/project/[projectId]/product/[productId]/frames.tsx
@@ -1,19 +1,36 @@
 import { useRouter } from 'next/router'
-import { useStore } from '../../../../../lib/store'
+import { useStore, GeneratedImage } from '../../../../../lib/store'
 import ProgressBar from '../../../../../components/ProgressBar'
+import FrameGenerationPanel from '../../../../../components/FrameGenerationPanel'
 
 export default function FramesPage() {
   const router = useRouter()
   const { projectId, productId } = router.query as { projectId: string; productId: string }
   const project = useStore(s => s.projects.find(p => p.id === projectId))
+  const updateProduct = useStore(s => s.updateProduct)
+
   if (!project) return <p className="p-6">Проект не найден</p>
   const product = project.products.find(p => p.id === productId)
   if (!product) return <p className="p-6">Продукт не найден</p>
+
+  const handleSave = (frames: Record<string, GeneratedImage>) => {
+    updateProduct(project.id, { ...product, frames })
+  }
+
   return (
     <div className="p-6 space-y-4">
       <ProgressBar current={3} />
       <h1 className="text-2xl font-bold mb-4">Ключевые кадры для {product.name}</h1>
-      <p>Здесь будет генерация ключевых кадров.</p>
+      {product.script && (
+        <FrameGenerationPanel
+          projectId={project.id}
+          productId={product.id}
+          scenes={product.script.storyboard}
+          initialFrames={product.frames}
+          onSave={handleSave}
+        />
+      )}
     </div>
   )
 }
+

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 body {
-  @apply bg-gradient-to-br from-[#40E0D0] to-[#C084FC] font-sans;
+  @apply bg-gradient-to-br from-[#40E0D0] to-[#C084FC];
   color: white;
 }
 


### PR DESCRIPTION
## Summary
- define `GeneratedImage` type and add `frames` to `Product`
- add Frame generation components and progress footer
- implement key frame generation page with style gallery and image variants
- mock APIs for styles, image generation and selection
- update global styles

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68838b82c9388320a6346c4f48ee5119