### PR TITLE
Add animation generation stage

### DIFF
--- a/frontend/components/AnimationPanel.tsx
+++ b/frontend/components/AnimationPanel.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+import { Scene, GeneratedImage, GeneratedVideo } from '../lib/store'
+import SceneAnimationCard from './SceneAnimationCard'
+import ProgressFooter from './ProgressFooter'
+import SettingsPanel from './SettingsPanel'
+import { useRouter } from 'next/router'
+
+interface Props {
+  projectId: string
+  productId: string
+  scenes: Scene[]
+  keyframes: Record<string, GeneratedImage>
+  initialVideos?: Record<string, GeneratedVideo>
+  onSave: (videos: Record<string, GeneratedVideo>) => void
+}
+
+export default function AnimationPanel({ projectId, productId, scenes, keyframes, initialVideos, onSave }: Props) {
+  const router = useRouter()
+  const [durations, setDurations] = useState<Record<string, number>>(() => {
+    const obj: Record<string, number> = {}
+    scenes.forEach(sc => { obj[sc.id] = 5 })
+    return obj
+  })
+  const [generators, setGenerators] = useState<Record<string, string>>(() => {
+    const obj: Record<string, string> = {}
+    scenes.forEach(sc => { obj[sc.id] = 'kling' })
+    return obj
+  })
+  const [videos, setVideos] = useState<Record<string, GeneratedVideo[]>>({})
+  const [selected, setSelected] = useState<Record<string, GeneratedVideo>>(initialVideos || {})
+  const [loading, setLoading] = useState<Record<string, boolean>>({})
+  const [apiKeys, setApiKeys] = useState<Record<string, string>>({ kling: '', 'wav2.1': '' })
+
+  const generate = async (sceneId: string) => {
+    setLoading(l => ({ ...l, [sceneId]: true }))
+    const res = await fetch('/api/generate-video', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sceneId,
+        generator: generators[sceneId],
+        duration: durations[sceneId],
+        imageUrl: keyframes[sceneId]?.url,
+        lipsyncText: scenes.find(sc => sc.id === sceneId)?.lipsyncText,
+        apiKey: apiKeys[generators[sceneId]]
+      })
+    })
+    const data: GeneratedVideo = await res.json()
+    setVideos(v => ({ ...v, [sceneId]: [...(v[sceneId] || []), data] }))
+    setLoading(l => ({ ...l, [sceneId]: false }))
+  }
+
+  const select = (sceneId: string, video: GeneratedVideo) => {
+    const next = { ...selected, [sceneId]: video }
+    setSelected(next)
+    onSave(next)
+  }
+
+  const remove = (sceneId: string, videoId: string) => {
+    setVideos(v => ({ ...v, [sceneId]: (v[sceneId] || []).filter(vv => vv.id !== videoId) }))
+    if (selected[sceneId]?.id === videoId) {
+      const next = { ...selected }
+      delete next[sceneId]
+      setSelected(next)
+      onSave(next)
+    }
+  }
+
+  const allSelected = scenes.every(sc => selected[sc.id])
+
+  const goNext = () => {
+    router.push(`/project/${projectId}/product/${productId}/post`)
+  }
+
+  return (
+    <div className="space-y-6 pb-24">
+      <SettingsPanel apiKeys={apiKeys} onChange={setApiKeys} />
+      {scenes.map(sc => (
+        <SceneAnimationCard
+          key={sc.id}
+          scene={sc}
+          keyframe={keyframes[sc.id]}
+          duration={durations[sc.id]}
+          generator={generators[sc.id]}
+          videos={videos[sc.id]}
+          generating={loading[sc.id]}
+          selected={selected[sc.id]}
+          onDurationChange={val => setDurations(d => ({ ...d, [sc.id]: val }))}
+          onGeneratorChange={val => setGenerators(g => ({ ...g, [sc.id]: val }))}
+          onGenerate={() => generate(sc.id)}
+          onSelectVideo={vid => select(sc.id, vid)}
+          onDeleteVideo={id => remove(sc.id, id)}
+        />
+      ))}
+      <ProgressFooter selected={Object.keys(selected).length} total={scenes.length} disabled={!allSelected} onNext={goNext} />
+    </div>
+  )
+}

--- a/frontend/components/GeneratorSelect.tsx
+++ b/frontend/components/GeneratorSelect.tsx
@@ -1,0 +1,25 @@
+interface Props {
+  value: string
+  onChange: (val: string) => void
+}
+
+const generators = [
+  { id: 'kling', title: 'Kling' },
+  { id: 'wav2.1', title: 'Wav 2.1' }
+]
+
+export default function GeneratorSelect({ value, onChange }: Props) {
+  return (
+    <select
+      className="border rounded px-2 py-1"
+      value={value}
+      onChange={e => onChange(e.target.value)}
+    >
+      {generators.map(g => (
+        <option key={g.id} value={g.id}>
+          {g.title}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/frontend/components/ProgressFooter.tsx
+++ b/frontend/components/ProgressFooter.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  selected: number
+  total: number
+  disabled?: boolean
+  onNext: () => void
+}
+
+export default function ProgressFooter({ selected, total, disabled, onNext }: Props) {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-white shadow-inner p-4 flex justify-between items-center">
+      <span>Выбрано {selected} из {total} сцен</span>
+      <button onClick={onNext} disabled={disabled} className="bg-brandTurquoise text-white px-4 py-2 rounded disabled:opacity-50">Перейти к постобработке</button>
+    </div>
+  )
+}

--- a/frontend/components/SceneAnimationCard.tsx
+++ b/frontend/components/SceneAnimationCard.tsx
@@ -1,0 +1,73 @@
+import { Scene, GeneratedImage, GeneratedVideo } from '../lib/store'
+import GeneratorSelect from './GeneratorSelect'
+import VideoPreview from './VideoPreview'
+
+interface Props {
+  scene: Scene
+  keyframe?: GeneratedImage
+  duration: number
+  generator: string
+  videos?: GeneratedVideo[]
+  generating?: boolean
+  selected?: GeneratedVideo
+  onDurationChange: (val: number) => void
+  onGeneratorChange: (val: string) => void
+  onGenerate: () => void
+  onSelectVideo: (video: GeneratedVideo) => void
+  onDeleteVideo: (id: string) => void
+}
+
+export default function SceneAnimationCard({
+  scene,
+  keyframe,
+  duration,
+  generator,
+  videos,
+  generating,
+  selected,
+  onDurationChange,
+  onGeneratorChange,
+  onGenerate,
+  onSelectVideo,
+  onDeleteVideo
+}: Props) {
+  return (
+    <div className="bg-white rounded-xl shadow-lg p-4 space-y-2">
+      <h3 className="font-semibold">{scene.title}</h3>
+      {keyframe && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={keyframe.url} alt="keyframe" className="w-full h-40 object-cover" />
+      )}
+      <input
+        type="number"
+        className="border rounded px-2 py-1 w-24"
+        value={duration}
+        onChange={e => onDurationChange(Number(e.target.value))}
+      />
+      <GeneratorSelect value={generator} onChange={onGeneratorChange} />
+      {scene.lipsync && scene.lipsyncText && (
+        <p className="text-sm italic">{scene.lipsyncText}</p>
+      )}
+      {videos && videos.length > 0 ? (
+        <div className="space-y-2">
+          {videos.map(v => (
+            <VideoPreview
+              key={v.id}
+              video={v}
+              selected={selected?.id === v.id}
+              onSelect={() => onSelectVideo(v)}
+              onDelete={() => onDeleteVideo(v.id)}
+            />
+          ))}
+          <button onClick={onGenerate} className="bg-brandPink text-white px-2 py-1 rounded">
+            Перегенерировать
+          </button>
+        </div>
+      ) : (
+        <button onClick={onGenerate} disabled={generating} className="bg-brandTurquoise text-white px-4 py-2 rounded">
+          {generating ? 'Генерация...' : 'Сгенерировать видео'}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/SettingsPanel.tsx
+++ b/frontend/components/SettingsPanel.tsx
@@ -1,0 +1,22 @@
+interface Props {
+  apiKeys: Record<string, string>
+  onChange: (keys: Record<string, string>) => void
+}
+
+export default function SettingsPanel({ apiKeys, onChange }: Props) {
+  return (
+    <div className="bg-white shadow p-4 rounded space-y-2">
+      <h3 className="font-semibold">Настройки API ключей</h3>
+      {Object.entries(apiKeys).map(([key, val]) => (
+        <div key={key} className="flex items-center space-x-2">
+          <label className="w-24 capitalize">{key}</label>
+          <input
+            className="border rounded px-2 py-1 flex-1"
+            value={val}
+            onChange={e => onChange({ ...apiKeys, [key]: e.target.value })}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/components/VideoPreview.tsx
+++ b/frontend/components/VideoPreview.tsx
@@ -1,0 +1,20 @@
+import { GeneratedVideo } from '../lib/store'
+
+interface Props {
+  video: GeneratedVideo
+  selected?: boolean
+  onSelect: () => void
+  onDelete: () => void
+}
+
+export default function VideoPreview({ video, selected, onSelect, onDelete }: Props) {
+  return (
+    <div className={`border rounded p-2 space-y-2 ${selected ? 'border-brandViolet' : 'border-transparent'}`}> 
+      <video src={video.url} controls className="w-full h-40 object-cover" />
+      <div className="flex space-x-2">
+        <button onClick={onSelect} className="bg-brandTurquoise text-white px-2 py-1 rounded">Выбрать</button>
+        <button onClick={onDelete} className="bg-brandPink text-white px-2 py-1 rounded">Удалить</button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/lib/store.ts
+++ b/frontend/lib/store.ts
@@ -29,6 +29,16 @@ export interface GeneratedImage {
   promptUsed: string;
 }
 
+export interface GeneratedVideo {
+  id: string
+  sceneId: string
+  url: string
+  thumbnail: string
+  generator: string
+  duration: number
+  lipsyncUsed: boolean
+}
+
 export interface Product {
   id: string;
   name: string;
@@ -45,6 +55,10 @@ export interface Product {
    * Map of sceneId to chosen image.
    */
   frames?: Record<string, GeneratedImage>;
+  /**
+   * Selected final videos for scenes.
+   */
+  videos?: Record<string, GeneratedVideo>;
   roadmap: RoadmapStep[];
 }
 

--- a/frontend/pages/api/generate-video.ts
+++ b/frontend/pages/api/generate-video.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { v4 as uuid } from 'uuid'
+import { GeneratedVideo } from '../../lib/store'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse<GeneratedVideo>) {
+  if (req.method !== 'POST') {
+    res.status(405).end()
+    return
+  }
+
+  const { sceneId, generator, duration, imageUrl, lipsyncText } = req.body
+  const video: GeneratedVideo = {
+    id: uuid(),
+    sceneId,
+    url: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+    thumbnail: imageUrl,
+    generator,
+    duration,
+    lipsyncUsed: Boolean(lipsyncText)
+  }
+  res.status(200).json(video)
+}

--- a/frontend/pages/project/[projectId]/product/[productId]/animation.tsx
+++ b/frontend/pages/project/[projectId]/product/[productId]/animation.tsx
@@ -1,0 +1,36 @@
+import { useRouter } from 'next/router'
+import { useStore, GeneratedVideo } from '../../../../../lib/store'
+import AnimationPanel from '../../../../../components/AnimationPanel'
+import ProgressBar from '../../../../../components/ProgressBar'
+
+export default function AnimationPage() {
+  const router = useRouter()
+  const { projectId, productId } = router.query as { projectId: string; productId: string }
+  const project = useStore(s => s.projects.find(p => p.id === projectId))
+  const updateProduct = useStore(s => s.updateProduct)
+
+  if (!project) return <p className="p-6">Проект не найден</p>
+  const product = project.products.find(p => p.id === productId)
+  if (!product) return <p className="p-6">Продукт не найден</p>
+
+  const handleSave = (videos: Record<string, GeneratedVideo>) => {
+    updateProduct(project.id, { ...product, videos })
+  }
+
+  return (
+    <div className="p-6 space-y-4">
+      <ProgressBar current={4} />
+      <h1 className="text-2xl font-bold mb-4">Анимация для {product.name}</h1>
+      {product.frames && product.script && (
+        <AnimationPanel
+          projectId={project.id}
+          productId={product.id}
+          scenes={product.script.storyboard}
+          keyframes={product.frames}
+          initialVideos={product.videos}
+          onSave={handleSave}
+        />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add animation generation page and components
- store generated videos in Zustand store
- handle video generation API route
- mock animation workflow UI with generator select and video previews

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_6883911839608320b010f14a4c86b174