### PR TITLE
Add video post-processing stage

### DIFF
--- a/frontend/components/ArtifactOverlay.tsx
+++ b/frontend/components/ArtifactOverlay.tsx
@@ -1,0 +1,18 @@
+interface Props {
+  frames: number[]
+  totalFrames: number
+}
+
+export default function ArtifactOverlay({ frames, totalFrames }: Props) {
+  return (
+    <div className="relative h-2 bg-gray-200 rounded">
+      {frames.map(f => (
+        <div
+          key={f}
+          style={{ left: `${(f / totalFrames) * 100}%` }}
+          className="absolute top-0 bottom-0 w-1 bg-red-600"
+        />
+      ))}
+    </div>
+  )
+}

--- a/frontend/components/PostProcessingCard.tsx
+++ b/frontend/components/PostProcessingCard.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+import QualityIndicator from './QualityIndicator'
+import ArtifactOverlay from './ArtifactOverlay'
+
+export interface VideoScene {
+  id: string
+  videoUrl: string
+  keyframeUrl: string
+  generator: string
+  duration: number
+}
+
+interface Props {
+  scene: VideoScene
+  onDone: (id: string) => void
+}
+
+interface QualityResult {
+  artifactFrames: number[]
+  type: 'blur' | 'warp' | 'noise' | 'blackframe'
+  qualityScore: number
+}
+
+export default function PostProcessingCard({ scene, onDone }: Props) {
+  const [quality, setQuality] = useState<QualityResult>()
+  const [to4k, setTo4k] = useState(true)
+  const [to60, setTo60] = useState(true)
+  const [status, setStatus] = useState<'pending' | 'done'>('pending')
+
+  const analyze = async () => {
+    const res = await fetch('/api/analyze-video', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sceneId: scene.id, videoUrl: scene.videoUrl })
+    })
+    const data: QualityResult = await res.json()
+    setQuality(data)
+  }
+
+  const remove = async () => {
+    if (!quality) return
+    await fetch('/api/remove-artifacts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sceneId: scene.id, artifactFrames: quality.artifactFrames })
+    })
+  }
+
+  const finalize = async () => {
+    await fetch('/api/upscale-video', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sceneId: scene.id, to4k, to60fps: to60 })
+    })
+    setStatus('done')
+    onDone(scene.id)
+  }
+
+  if (status === 'done') {
+    return (
+      <div className="bg-white rounded-xl shadow-lg p-4 space-y-2">
+        <p className="font-semibold">{scene.id} ✅ Обработано</p>
+      </div>
+    )
+  }
+
+  const totalFrames = Math.round(scene.duration * 30)
+
+  return (
+    <div className="bg-white rounded-xl shadow-lg p-4 space-y-2">
+      <video src={scene.videoUrl} controls className="w-full h-40 object-cover" />
+      {quality && <QualityIndicator score={quality.qualityScore} />}
+      {quality && quality.artifactFrames.length > 0 && (
+        <ArtifactOverlay frames={quality.artifactFrames} totalFrames={totalFrames} />
+      )}
+      <div className="flex space-x-2">
+        <button onClick={analyze} className="bg-indigo-600 hover:bg-indigo-500 text-white px-2 py-1 rounded">
+          Анализировать качество
+        </button>
+        {quality && quality.artifactFrames.length > 0 && (
+          <button onClick={remove} className="bg-indigo-600 hover:bg-indigo-500 text-white px-2 py-1 rounded">
+            Удалить артефакты
+          </button>
+        )}
+      </div>
+      <label className="flex items-center space-x-2 text-sm">
+        <input type="checkbox" checked={to4k} onChange={e => setTo4k(e.target.checked)} />
+        <span>Апскейлить до 4K</span>
+      </label>
+      <label className="flex items-center space-x-2 text-sm">
+        <input type="checkbox" checked={to60} onChange={e => setTo60(e.target.checked)} />
+        <span>Повысить FPS до 60</span>
+      </label>
+      <button onClick={finalize} className="bg-indigo-600 hover:bg-indigo-500 text-white px-4 py-2 rounded">
+        Готово
+      </button>
+    </div>
+  )
+}

--- a/frontend/components/PostProcessingPanel.tsx
+++ b/frontend/components/PostProcessingPanel.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+import PostProcessingCard, { VideoScene } from './PostProcessingCard'
+import { useRouter } from 'next/router'
+
+interface Props {
+  projectId: string
+  productId: string
+  scenes: VideoScene[]
+}
+
+export default function PostProcessingPanel({ projectId, productId, scenes }: Props) {
+  const router = useRouter()
+  const [done, setDone] = useState<Record<string, boolean>>({})
+
+  const markDone = (id: string) => setDone(d => ({ ...d, [id]: true }))
+  const allDone = scenes.every(sc => done[sc.id])
+
+  const goNext = () => {
+    router.push(`/project/${projectId}/product/${productId}/montage`)
+  }
+
+  return (
+    <div className="space-y-6 pb-24">
+      {scenes.map(sc => (
+        <PostProcessingCard key={sc.id} scene={sc} onDone={markDone} />
+      ))}
+      <div className="fixed bottom-0 left-0 right-0 bg-white shadow-inner p-4 flex justify-between items-center">
+        <span>Обработано {Object.keys(done).length} из {scenes.length} сцен</span>
+        <button onClick={goNext} disabled={!allDone} className="bg-indigo-600 hover:bg-indigo-500 text-white px-4 py-2 rounded disabled:opacity-50">
+          Перейти к монтажу
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/QualityIndicator.tsx
+++ b/frontend/components/QualityIndicator.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  score: number
+}
+
+export default function QualityIndicator({ score }: Props) {
+  const color = score > 80 ? 'bg-green-500' : score > 60 ? 'bg-yellow-500' : 'bg-red-500'
+  return (
+    <div className="w-full space-y-1">
+      <div className="relative h-2 bg-gray-200 rounded overflow-hidden">
+        <div style={{ width: `${score}%` }} className={`${color} h-2`} />
+      </div>
+      <span className="text-sm">Качество: {score}/100</span>
+    </div>
+  )
+}

--- a/frontend/pages/api/analyze-video.ts
+++ b/frontend/pages/api/analyze-video.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).end()
+    return
+  }
+
+  const { sceneId, videoUrl } = req.body
+  // Mock analysis result
+  const result = {
+    artifactFrames: [1, 15, 30],
+    type: 'blur',
+    qualityScore: 78
+  }
+
+  res.status(200).json(result)
+}

--- a/frontend/pages/api/apply-anix-interpolation.ts
+++ b/frontend/pages/api/apply-anix-interpolation.ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).end()
+    return
+  }
+
+  // In real app PNGs would be merged back into video
+  res.status(200).json({ ok: true })
+}

--- a/frontend/pages/api/remove-artifacts.ts
+++ b/frontend/pages/api/remove-artifacts.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).end()
+    return
+  }
+
+  const { sceneId, artifactFrames } = req.body
+  // Mock removal action
+  res.status(200).json({ ok: true })
+}

--- a/frontend/pages/api/upscale-video.ts
+++ b/frontend/pages/api/upscale-video.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).end()
+    return
+  }
+
+  const { sceneId, to4k, to60fps } = req.body
+  // Mock upscale
+  res.status(200).json({ ok: true })
+}

--- a/frontend/pages/project/[projectId]/product/[productId]/post.tsx
+++ b/frontend/pages/project/[projectId]/product/[productId]/post.tsx
@@ -1,0 +1,36 @@
+import { useRouter } from 'next/router'
+import { useStore } from '../../../../../lib/store'
+import ProgressBar from '../../../../../components/ProgressBar'
+import PostProcessingPanel from '../../../../../components/PostProcessingPanel'
+
+export default function PostPage() {
+  const router = useRouter()
+  const { projectId, productId } = router.query as { projectId: string; productId: string }
+  const project = useStore(s => s.projects.find(p => p.id === projectId))
+
+  if (!project) return <p className="p-6">Проект не найден</p>
+  const product = project.products.find(p => p.id === productId)
+  if (!product) return <p className="p-6">Продукт не найден</p>
+
+  const scenes = (product.script?.storyboard || []).map(sc => {
+    const vid = product.videos?.[sc.id]
+    const img = product.frames?.[sc.id]
+    if (!vid) return null
+    return {
+      id: sc.id,
+      videoUrl: vid.url,
+      keyframeUrl: img?.url || '',
+      generator: vid.generator,
+      duration: vid.duration
+    }
+  }).filter(Boolean) as any[]
+
+  return (
+    <div className="p-6 space-y-4">
+      <ProgressBar current={5} />
+      <h1 className="text-2xl font-bold mb-4">Постобработка для {product.name}</h1>
+      <PostProcessingPanel projectId={project.id} productId={product.id} scenes={scenes} />
+    </div>
+  )
+}
+

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -7,10 +7,16 @@ body {
   color: white;
 }
 
-h1, h2 {
-  @apply font-bold;
+@layer base {
+  h1, h2 {
+    font-weight: 700;
+  }
 }
 
 a {
-  @apply transition-all hover:text-yellow-300;
+  transition-property: all;
+  transition-duration: 150ms;
+}
+a:hover {
+  color: #facc15;
 }


### PR DESCRIPTION
## Summary
- add post-processing API stubs
- create post-processing panel with per‑scene cards
- show quality indicator and artifact overlay
- link new page into project workflow
- adjust global styles to avoid Tailwind build errors

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883a94e7e5c832093ff0223df51225c