### PR TITLE
Add project creation/edit pages

### DIFF
--- a/frontend/components/ProjectVideoForm.tsx
+++ b/frontend/components/ProjectVideoForm.tsx
@@ -1,0 +1,98 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+const schema = z.object({
+  title: z.string().min(1, 'Обязательное поле'),
+  description: z.string().optional(),
+  format: z.enum(['16:9', '9:16', '1:1']),
+  target_audience: z.string().optional(),
+  goals: z.string().optional(),
+  tone: z.enum(['Информативный', 'Эмоциональный', 'Провокационный']),
+  style: z.enum(['2D', '3D', 'Screencast', 'Hand-drawn'])
+});
+
+export type ProjectFormData = z.infer<typeof schema>;
+
+interface Props {
+  initial?: Partial<ProjectFormData>;
+  isPro?: boolean;
+  onSave: (data: ProjectFormData) => void;
+}
+
+export default function ProjectVideoForm({ initial, onSave, isPro }: Props) {
+  const { register, handleSubmit, setValue, formState: { errors } } = useForm<ProjectFormData>({
+    resolver: zodResolver(schema),
+    defaultValues: initial as any
+  });
+
+  const startRecognition = (field: keyof ProjectFormData) => {
+    const SpeechRecognition = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    if (!SpeechRecognition) return;
+    const rec = new SpeechRecognition();
+    rec.lang = 'ru-RU';
+    rec.onresult = (e: any) => {
+      const text = Array.from(e.results).map((r: any) => r[0].transcript).join(' ');
+      setValue(field, text);
+    };
+    rec.start();
+  };
+
+  const Mic = (field: keyof ProjectFormData) => (
+    isPro ? (
+      <button type="button" onClick={() => startRecognition(field)} className="ml-2 text-gray-500">
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+          <path d="M10 2a2 2 0 00-2 2v6a2 2 0 104 0V4a2 2 0 00-2-2z" />
+          <path fillRule="evenodd" d="M5 10a5 5 0 0010 0h2a7 7 0 01-14 0h2z" clipRule="evenodd" />
+          <path d="M11 18h-2v-2h2v2z" />
+        </svg>
+      </button>
+    ) : null
+  );
+
+  const renderInput = (field: keyof ProjectFormData, label: string) => (
+    <div>
+      <label className="block mb-1">{label}</label>
+      <div className="flex items-center">
+        <input className="w-full border rounded px-3 py-2" {...register(field)} />
+        {Mic(field)}
+      </div>
+      {(errors as any)[field] && <p className="text-red-500 text-sm">{(errors as any)[field].message}</p>}
+    </div>
+  );
+
+  const renderArea = (field: keyof ProjectFormData, label: string) => (
+    <div>
+      <label className="block mb-1">{label}</label>
+      <div className="flex items-start">
+        <textarea className="w-full border rounded px-3 py-2" {...register(field)} />
+        {Mic(field)}
+      </div>
+    </div>
+  );
+
+  const renderSelect = (field: keyof ProjectFormData, label: string, options: string[]) => (
+    <div>
+      <label className="block mb-1">{label}</label>
+      <div className="flex items-center">
+        <select className="w-full border rounded px-3 py-2" {...register(field)}>
+          {options.map(o => <option key={o} value={o}>{o}</option>)}
+        </select>
+        {Mic(field)}
+      </div>
+    </div>
+  );
+
+  return (
+    <form onSubmit={handleSubmit(onSave)} className="space-y-4">
+      {renderInput('title', 'Название проекта')}
+      {renderArea('description', 'Описание')}
+      {renderSelect('format', 'Формат', ['16:9', '9:16', '1:1'])}
+      {renderArea('target_audience', 'Целевая аудитория')}
+      {renderArea('goals', 'Цель видео')}
+      {renderSelect('tone', 'Тональность', ['Информативный', 'Эмоциональный', 'Провокационный'])}
+      {renderSelect('style', 'Визуальный стиль', ['2D', '3D', 'Screencast', 'Hand-drawn'])}
+      <button type="submit" className="bg-brandTurquoise text-white px-4 py-2 rounded">Сохранить</button>
+    </form>
+  );
+}

--- a/frontend/pages/projects/[id]/edit.tsx
+++ b/frontend/pages/projects/[id]/edit.tsx
@@ -1,0 +1,45 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import toast from 'react-hot-toast';
+import ProjectVideoForm, { ProjectFormData } from '../../../components/ProjectVideoForm';
+
+export default function EditProjectPage() {
+  const router = useRouter();
+  const { id } = router.query as { id: string };
+  const { data: session } = useSession();
+  const isPro = (session as any)?.user?.mode === 'pro';
+  const [initial, setInitial] = useState<ProjectFormData | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`/api/projects/${id}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (data) setInitial(data);
+      });
+  }, [id]);
+
+  const handleSave = async (data: ProjectFormData) => {
+    const res = await fetch(`/api/projects/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    if (res.ok) {
+      toast.success('Проект обновлён');
+      router.push('/projects');
+    } else {
+      toast.error('Ошибка при сохранении');
+    }
+  };
+
+  if (!initial) return <p className="p-6">Загрузка...</p>;
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Редактирование проекта</h1>
+      <ProjectVideoForm initial={initial} onSave={handleSave} isPro={isPro} />
+    </div>
+  );
+}

--- a/frontend/pages/projects/new.tsx
+++ b/frontend/pages/projects/new.tsx
@@ -1,0 +1,31 @@
+import { useRouter } from 'next/router';
+import { useSession } from 'next-auth/react';
+import toast from 'react-hot-toast';
+import ProjectVideoForm, { ProjectFormData } from '../../components/ProjectVideoForm';
+
+export default function NewProjectPage() {
+  const router = useRouter();
+  const { data: session } = useSession();
+  const isPro = (session as any)?.user?.mode === 'pro';
+
+  const handleSave = async (data: ProjectFormData) => {
+    const res = await fetch('/api/projects', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    if (res.ok) {
+      toast.success('Проект создан');
+      router.push('/projects');
+    } else {
+      toast.error('Ошибка при сохранении');
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Новый проект</h1>
+      <ProjectVideoForm onSave={handleSave} isPro={isPro} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ProjectVideoForm` component with optional voice dictation using Web Speech API
- create page for new project `/projects/new`
- create page for editing project `/projects/[id]/edit`

## Testing
- `npx tsc -p frontend/tsconfig.json --noEmit`
- `npm run build` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_688ce6b9075083208609b6f7621b844f