### PR TITLE
Fix tests to use UUIDs

### DIFF
--- a/project-api/package-lock.json
+++ b/project-api/package-lock.json
@@ -17,7 +17,8 @@
       "devDependencies": {
         "jest": "^29.6.1",
         "nodemon": "^3.0.2",
-        "supertest": "^6.3.3"
+        "supertest": "^6.3.3",
+        "uuid": "^11.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4861,6 +4862,20 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/project-api/package.json
+++ b/project-api/package.json
@@ -20,7 +20,8 @@
   },
   "devDependencies": {
     "jest": "^29.6.1",
+    "nodemon": "^3.0.2",
     "supertest": "^6.3.3",
-    "nodemon": "^3.0.2"
+    "uuid": "^11.1.0"
   }
 }

--- a/project-api/tests/projects.test.js
+++ b/project-api/tests/projects.test.js
@@ -1,7 +1,10 @@
 const request = require('supertest');
+const { v4: uuidv4 } = require('uuid');
 const app = require('../src/index');
 const pool = require('../src/db');
 const { createTable } = require('../src/models/projectModel');
+
+const testUserId = uuidv4();
 
 beforeAll(async () => {
   await createTable();
@@ -19,7 +22,7 @@ describe('POST /api/projects', () => {
   it('creates a project successfully', async () => {
     const res = await request(app)
       .post('/api/projects')
-      .set('Authorization', 'Bearer user-1')
+      .set('Authorization', `Bearer ${testUserId}`)
       .send({ title: 'Test', format: '16:9' });
     expect(res.status).toBe(201);
     expect(res.body.title).toBe('Test');
@@ -28,7 +31,7 @@ describe('POST /api/projects', () => {
   it('returns validation error for empty title', async () => {
     const res = await request(app)
       .post('/api/projects')
-      .set('Authorization', 'Bearer user-1')
+      .set('Authorization', `Bearer ${testUserId}`)
       .send({ title: '' });
     expect(res.status).toBe(400);
   });
@@ -38,11 +41,11 @@ describe('GET /api/projects', () => {
   it('returns list of projects', async () => {
     await request(app)
       .post('/api/projects')
-      .set('Authorization', 'Bearer user-1')
+      .set('Authorization', `Bearer ${testUserId}`)
       .send({ title: 'Project 1', format: '16:9' });
     const res = await request(app)
       .get('/api/projects')
-      .set('Authorization', 'Bearer user-1');
+      .set('Authorization', `Bearer ${testUserId}`);
     expect(res.status).toBe(200);
     expect(res.body.length).toBe(1);
   });
@@ -52,12 +55,12 @@ describe('GET /api/projects/:id', () => {
   it('returns project by id', async () => {
     const createRes = await request(app)
       .post('/api/projects')
-      .set('Authorization', 'Bearer user-1')
+      .set('Authorization', `Bearer ${testUserId}`)
       .send({ title: 'Project', format: '16:9' });
     const id = createRes.body.id;
     const res = await request(app)
       .get(`/api/projects/${id}`)
-      .set('Authorization', 'Bearer user-1');
+      .set('Authorization', `Bearer ${testUserId}`);
     expect(res.status).toBe(200);
     expect(res.body.id).toBe(id);
   });
@@ -65,7 +68,7 @@ describe('GET /api/projects/:id', () => {
   it('returns 404 if not found', async () => {
     const res = await request(app)
       .get('/api/projects/9999')
-      .set('Authorization', 'Bearer user-1');
+      .set('Authorization', `Bearer ${testUserId}`);
     expect(res.status).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary
- install uuid library
- update tests to generate a uuid for authorization
- adjust package lock

## Testing
- `DATABASE_URL=postgresql://user:password@localhost:5432/projects_db npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cea8497b483208f5157c66fddb4f1