### PR TITLE
Use project-api for project data and cache in store

### DIFF
--- a/frontend/lib/store.ts
+++ b/frontend/lib/store.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 
 export interface RoadmapStep {
   id: string;
@@ -76,33 +75,44 @@ export interface Project {
 
 interface StoreState {
   projects: Project[];
-  addProject: (project: Project) => void;
+  fetchProjects: () => Promise<void>;
+  createProject: (data: Partial<Project>) => Promise<void>;
   updateProject: (project: Project) => void;
   addProduct: (projectId: string, product: Product) => void;
   updateProduct: (projectId: string, product: Product) => void;
 }
 
-export const useStore = create<StoreState>()(
-  persist(
-    (set, get) => ({
-      projects: [],
-      addProject: (project) =>
-        set({ projects: [...get().projects, project] }),
-      updateProject: (project) =>
-        set({ projects: get().projects.map(p => p.id === project.id ? project : p) }),
-      addProduct: (projectId, product) =>
-        set({
-          projects: get().projects.map(p => p.id === projectId ? { ...p, products: [...p.products, product] } : p)
-        }),
-      updateProduct: (projectId, product) =>
-        set({
-          projects: get().projects.map(p =>
-            p.id === projectId
-              ? { ...p, products: p.products.map(pr => pr.id === product.id ? product : pr) }
-              : p
-          )
-        }),
+export const useStore = create<StoreState>((set, get) => ({
+  projects: [],
+  fetchProjects: async () => {
+    const res = await fetch('/api/projects');
+    if (res.ok) {
+      const data = await res.json();
+      set({ projects: data });
+    }
+  },
+  createProject: async (data) => {
+    const res = await fetch('/api/projects', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    if (!res.ok) throw new Error('Failed to create project');
+    const project = await res.json();
+    set({ projects: [...get().projects, project] });
+  },
+  updateProject: (project) =>
+    set({ projects: get().projects.map(p => p.id === project.id ? project : p) }),
+  addProduct: (projectId, product) =>
+    set({
+      projects: get().projects.map(p => p.id === projectId ? { ...p, products: [...p.products, product] } : p)
     }),
-    { name: 'ae-projects' }
-  )
-);
+  updateProduct: (projectId, product) =>
+    set({
+      projects: get().projects.map(p =>
+        p.id === projectId
+          ? { ...p, products: p.products.map(pr => pr.id === product.id ? product : pr) }
+          : p
+      )
+    }),
+}));

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -1,40 +1,35 @@
-import { useSession, getSession } from 'next-auth/react';
+import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import ProjectCard from '../components/ProjectCard';
 import CompanyForm from '../components/CompanyForm';
 import { Dialog } from '@headlessui/react';
-import { useStore, Project } from '../lib/store';
-import { v4 as uuid } from 'uuid';
+import { useStore } from '../lib/store';
 import toast from 'react-hot-toast';
 
 export default function Dashboard() {
   const { data: session, status } = useSession();
   const router = useRouter();
   const projects = useStore(s => s.projects);
-  const addProject = useStore(s => s.addProject);
+  const fetchProjects = useStore(s => s.fetchProjects);
+  const createProject = useStore(s => s.createProject);
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
     if (status === 'unauthenticated') router.replace('/auth');
-  }, [status, router]);
+    if (status === 'authenticated') fetchProjects();
+  }, [status, router, fetchProjects]);
 
   if (!session) return null;
 
-  const handleCreate = (data: any) => {
-    const project: Project = {
-      id: uuid(),
-      companyName: data.companyName,
-      sphere: data.sphere,
-      description: data.description,
-      niche: data.niche,
-      mission: data.mission,
-      createdAt: new Date().toISOString(),
-      products: [],
-    };
-    addProject(project);
-    setOpen(false);
-    toast.success('Проект создан');
+  const handleCreate = async (data: any) => {
+    try {
+      await createProject(data);
+      setOpen(false);
+      toast.success('Проект создан');
+    } catch (e) {
+      toast.error('Ошибка при создании проекта');
+    }
   };
 
   return (

--- a/project-api/src/controllers/projectsController.js
+++ b/project-api/src/controllers/projectsController.js
@@ -31,8 +31,31 @@ async function getProjectById(req, res) {
   }
 }
 
+async function updateProject(req, res) {
+  try {
+    const project = await service.updateProject(req.userId, req.params.id, req.validatedBody);
+    if (!project) return res.status(404).json({ error: 'Not found' });
+    res.json(project);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+}
+
+async function deleteProject(req, res) {
+  try {
+    await service.deleteProject(req.userId, req.params.id);
+    res.status(204).end();
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+}
+
 module.exports = {
   createProject,
   getProjects,
   getProjectById,
+  updateProject,
+  deleteProject,
 };

--- a/project-api/src/models/projectModel.js
+++ b/project-api/src/models/projectModel.js
@@ -43,9 +43,33 @@ async function findProjectById(userId, id) {
   return rows[0];
 }
 
+async function updateProject(userId, id, data) {
+  const {
+    title,
+    description,
+    format,
+    target_audience,
+    goals,
+    tone,
+    style,
+  } = data;
+  const { rows } = await pool.query(
+    `UPDATE projects SET title = $1, description = $2, format = $3, target_audience = $4, goals = $5, tone = $6, style = $7
+     WHERE id = $8 AND user_id = $9 RETURNING *`,
+    [title, description, format, target_audience, goals, tone, style, id, userId]
+  );
+  return rows[0];
+}
+
+async function deleteProject(userId, id) {
+  await pool.query('DELETE FROM projects WHERE id = $1 AND user_id = $2', [id, userId]);
+}
+
 module.exports = {
   createTable,
   insertProject,
   findProjectsByUser,
   findProjectById,
+  updateProject,
+  deleteProject,
 };

--- a/project-api/src/routes/projectsRoutes.js
+++ b/project-api/src/routes/projectsRoutes.js
@@ -50,4 +50,8 @@ router.get('/projects', getUserId, controller.getProjects);
  */
 router.get('/projects/:id', getUserId, controller.getProjectById);
 
+router.put('/projects/:id', getUserId, validateProject, controller.updateProject);
+
+router.delete('/projects/:id', getUserId, controller.deleteProject);
+
 module.exports = router;

--- a/project-api/src/services/projectsService.js
+++ b/project-api/src/services/projectsService.js
@@ -12,8 +12,18 @@ async function getProjectById(userId, id) {
   return model.findProjectById(userId, id);
 }
 
+async function updateProject(userId, id, data) {
+  return model.updateProject(userId, id, data);
+}
+
+async function deleteProject(userId, id) {
+  return model.deleteProject(userId, id);
+}
+
 module.exports = {
   createProject,
   getProjects,
   getProjectById,
+  updateProject,
+  deleteProject,
 };

--- a/project-api/tests/projects.test.js
+++ b/project-api/tests/projects.test.js
@@ -72,3 +72,37 @@ describe('GET /api/projects/:id', () => {
     expect(res.status).toBe(404);
   });
 });
+
+describe('PUT /api/projects/:id', () => {
+  it('updates a project', async () => {
+    const createRes = await request(app)
+      .post('/api/projects')
+      .set('Authorization', `Bearer ${testUserId}`)
+      .send({ title: 'Old', format: '16:9' });
+    const id = createRes.body.id;
+    const res = await request(app)
+      .put(`/api/projects/${id}`)
+      .set('Authorization', `Bearer ${testUserId}`)
+      .send({ title: 'New', format: '1:1' });
+    expect(res.status).toBe(200);
+    expect(res.body.title).toBe('New');
+  });
+});
+
+describe('DELETE /api/projects/:id', () => {
+  it('deletes a project', async () => {
+    const createRes = await request(app)
+      .post('/api/projects')
+      .set('Authorization', `Bearer ${testUserId}`)
+      .send({ title: 'ToDelete', format: '16:9' });
+    const id = createRes.body.id;
+    const res = await request(app)
+      .delete(`/api/projects/${id}`)
+      .set('Authorization', `Bearer ${testUserId}`);
+    expect(res.status).toBe(204);
+    const listRes = await request(app)
+      .get('/api/projects')
+      .set('Authorization', `Bearer ${testUserId}`);
+    expect(listRes.body.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Proxy project requests through project-api instead of an in-memory array
- Add update and delete endpoints to project-api
- Fetch projects via GET and create via POST in the Zustand store

## Testing
- `DATABASE_URL=postgresql://user:password@localhost:5432/appdb npm test` in `project-api`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68939618f9a0832094c0866e0acb730c