### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build-deploy:
@@ -19,9 +23,11 @@ jobs:
       - name: Install deps
         run: |
           cd frontend
-          npm install
+          npm ci
 
       - name: Build static site
+        env:
+          BASE_PATH: /${{ github.event.repository.name }}
         run: |
           cd frontend
           npm run export
@@ -30,4 +36,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
           publish_dir: ./frontend/out

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,8 +1,12 @@
 /** @type {import('next').NextConfig} */
+const basePath = process.env.BASE_PATH || ''
+
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   output: 'export',
+  basePath,
+  assetPrefix: basePath ? `${basePath}/` : '',
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
## Summary
- parameterize Next.js build for GitHub Pages via BASE_PATH
- enhance GitHub Pages workflow with explicit gh-pages publish and base path export

## Testing
- `npm test` (frontend)
- `npm run lint` (frontend)
- `npm test` (project-api) *(fails: connect ECONNREFUSED 127.0.0.1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_689b08b074a88320a2fb204fd0117a65